### PR TITLE
Updated so Lum could recognize the mods

### DIFF
--- a/zeobviouslyfakeacc.json
+++ b/zeobviouslyfakeacc.json
@@ -196,7 +196,7 @@
 				"notes":""
 			}
 		},{
-			"name":"Developer-Console",
+			"name":"DeveloperConsole",
 			"author":"<a href='https://github.com/FINDarkside' target='_blank'>FINDarkside</a> and <a href='https://github.com/zeobviouslyfakeacc' target='_blank'>zeobviouslyfakeacc</a>",
 			"authorURL":"-",
 			"version":"1.2.1",
@@ -234,7 +234,7 @@
 				"notes":""
 			}
 		},{
-			"name":"Disable-Chromatic-Aberration",
+			"name":"DisableChromaticAberration",
 			"author":"<a href='https://github.com/WulfMarius' target='_blank'>WulfMarius</a> and <a href='https://github.com/zeobviouslyfakeacc' target='_blank'>zeobviouslyfakeacc</a>",
 			"authorURL":"-",
 			"version":"4.0.0",
@@ -274,7 +274,7 @@
 				"notes":""
 			}
 		},{
-			"name":"Free-Look-In-Cars",
+			"name":"FreeLookInCars",
 			"author":"<a href='https://github.com/WulfMarius' target='_blank'>WulfMarius</a> and <a href='https://github.com/zeobviouslyfakeacc' target='_blank'>zeobviouslyfakeacc</a>",
 			"authorURL":"-",
 			"version":"4.0.0",


### PR DESCRIPTION
Lum is a new bot on the Modding discord server. It checks logs automatically and notifies users of common problems, including outdated mod versions. This works very well, but it can be quite picky about the naming. This issue was caused by inconsistent hyphenation between the mod output in the MelonLoader and the results on Xpazeman's website. Making this simple change will allow Lum to recognize these 3 mods.